### PR TITLE
[fix] Heading image is no longer blurry on mobile

### DIFF
--- a/app/(main)/_components/mobileheading.tsx
+++ b/app/(main)/_components/mobileheading.tsx
@@ -18,6 +18,7 @@ const MobileHeading = () => {
           alt="Keck Center"
           width={0}
           height={0}
+          unoptimized
         />
       </div>
       <div className="flex flex-col w-full justify-center items-center text-center z-10 gap-y-8 pt-5 pb-10 secondary-title">


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have tested my changes locally and they work
- [x] My pull request targets the `main` branch of this repository.
- [x] I have organized any project files to the best of my ability

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #17

<!-- Feel free to add any additional description of changes below this line -->
This pull request includes a small change to the `MobileHeading` component in the `mobileheading.tsx` file. The change adds the `unoptimized` attribute to an image element.

* [`app/(main)/_components/mobileheading.tsx`](diffhunk://#diff-3b67c8ea597c94e6578d47fda1996386cbe67124784f36c91b6def5ab92b4523R21): Added the `unoptimized` attribute to an image element to improve performance.
