### PR TITLE
[fix] Metadata warning no longer thrown on build

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,8 @@ import { Geist, Geist_Mono } from "next/font/google";
 
 import "./globals.css";
 
+import { mainWebsiteLink } from "@/lib/links";
+
 const geistSans = Geist({
   variable: "--font-geist-sans",
   subsets: ["latin"],
@@ -30,6 +32,7 @@ export const metadata: Metadata = {
       },
     ],
   },
+  metadataBase: new URL(mainWebsiteLink),
   openGraph: {
     images: "/social-images/opengraph-image.png",
   },

--- a/lib/links.ts
+++ b/lib/links.ts
@@ -1,4 +1,5 @@
 // Description: This file contains all the links used in the website.
+export const mainWebsiteLink = "https://pantherhacks.dev";
 export const gitHubLink = "https://github.com/PantherHacks/pantherhacks.dev";
 export const discordLink = "https://discord.gg/9NSwX5PxqC";
 export const instagramLink = "https://www.instagram.com/chapmancsclub/";


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have tested my changes locally and they work
- [x] My pull request targets the `main` branch of this repository.
- [x] I have organized any project files to the best of my ability

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
This pull request includes changes to the `app/layout.tsx` and `lib/links.ts` files to introduce and utilize a new constant for the main website link. The changes focus on improving the maintainability and consistency of link references in the codebase.

Improvements to link management:

* [`lib/links.ts`](diffhunk://#diff-1f959a20f72082f03d8610012eec9bdbaa51b8703c45a0485b84fe972bed7e6aR2): Added a new constant `mainWebsiteLink` to centralize the main website URL.
* [`app/layout.tsx`](diffhunk://#diff-eca96d2c09f31517696a26e1d0be4070e1fbab02831481bed006e275741d030bR6-R7): Imported the newly created `mainWebsiteLink` constant and used it to set the `metadataBase` property in the metadata object. [[1]](diffhunk://#diff-eca96d2c09f31517696a26e1d0be4070e1fbab02831481bed006e275741d030bR6-R7) [[2]](diffhunk://#diff-eca96d2c09f31517696a26e1d0be4070e1fbab02831481bed006e275741d030bR35)