### PR TITLE
[fix] Header related images no longer lazy load

### DIFF
--- a/app/(main)/_components/heading.tsx
+++ b/app/(main)/_components/heading.tsx
@@ -21,6 +21,7 @@ const Heading = () => {
             alt="Mountain"
             width={0}
             height={0}
+            loading="eager"
           />
         </ParallaxBannerLayer>
 
@@ -31,6 +32,7 @@ const Heading = () => {
             alt="Mountain"
             width={0}
             height={0}
+            loading="eager"
           />
         </ParallaxBannerLayer>
 
@@ -45,6 +47,7 @@ const Heading = () => {
             alt="Keck Center"
             width={0}
             height={0}
+            loading="eager"
           />
         </ParallaxBannerLayer>
 

--- a/app/(main)/_components/main-content.tsx
+++ b/app/(main)/_components/main-content.tsx
@@ -26,6 +26,7 @@ const MainContent = () => {
           alt=""
           aria-hidden
           className="w-full scale-105 translate-x-2 h-auto -translate-y-2"
+          loading="eager"
         />
       </div>
       <AboutSection />

--- a/app/(main)/_components/mobileheading.tsx
+++ b/app/(main)/_components/mobileheading.tsx
@@ -21,6 +21,7 @@ const MobileHeading = () => {
           width={0}
           height={0}
           draggable={false}
+          loading="eager"
           unoptimized
         />
       </div>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have tested my changes locally and they work
- [x] My pull request targets the `main` branch of this repository.
- [x] I have organized any project files to the best of my ability

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #51

<!-- Feel free to add any additional description of changes below this line -->
This pull request includes several changes to improve the loading performance of images in the `app/(main)/_components` directory by adding the `loading="eager"` attribute to various image components.

Changes to improve image loading performance:

* [`app/(main)/_components/heading.tsx`](diffhunk://#diff-38bcb41921a40de8ae1ed55132363f783274dc56e1bb2df9643e1a6d5c4128b4R24): Added `loading="eager"` attribute to images in three different locations to ensure they load as soon as possible. [[1]](diffhunk://#diff-38bcb41921a40de8ae1ed55132363f783274dc56e1bb2df9643e1a6d5c4128b4R24) [[2]](diffhunk://#diff-38bcb41921a40de8ae1ed55132363f783274dc56e1bb2df9643e1a6d5c4128b4R35) [[3]](diffhunk://#diff-38bcb41921a40de8ae1ed55132363f783274dc56e1bb2df9643e1a6d5c4128b4R50)
* [`app/(main)/_components/main-content.tsx`](diffhunk://#diff-bca88fd766f976eac9a0531fdae69d12d05f26bb6ba8f820aaa45b94d2037427R29): Added `loading="eager"` attribute to an image to improve its loading performance.
* [`app/(main)/_components/mobileheading.tsx`](diffhunk://#diff-3b67c8ea597c94e6578d47fda1996386cbe67124784f36c91b6def5ab92b4523R24): Added `loading="eager"` attribute to an image to ensure it loads immediately.