### PR TITLE
[added] /apply redirects you to application page

### DIFF
--- a/app/(application)/apply/page.tsx
+++ b/app/(application)/apply/page.tsx
@@ -1,0 +1,33 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { Loader2 } from "lucide-react";
+
+import Footer from "@/components/footer/footer";
+import Navbar from "@/components/navbar";
+import { applicationLink } from "@/lib/links";
+
+export default function Apply() {
+  redirect(applicationLink);
+
+  return (
+    <div className="flex flex-col justify-center items-center min-h-screen">
+      <Navbar />
+      <main className="flex flex-1 w-[100vw]">
+        <div className="flex flex-grow flex-col w-full">
+          <div id="about" className="flex flex-col items-center justify-center w-full py-40">
+            <h2 className="font-TangoSansBold text-6xl text-primary pb-10">Apply</h2>
+            <p className="mx-8 sm:mx-20 md:mx-24 text-center">
+              Redirecting you to the application. If this doesn't work, click{" "}
+              <Link href={applicationLink} className="underline hover:text-primary transition-colors">
+                here
+              </Link>
+              .
+            </p>
+            <Loader2 className="w-24 h-24 mt-10 animate-spin" />
+          </div>
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+}


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have tested my changes locally and they work
- [x] My pull request targets the `main` branch of this repository.
- [x] I have organized any project files to the best of my ability

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #66

<!-- Feel free to add any additional description of changes below this line -->
This pull request introduces a new `Apply` page to the application, which redirects users to the application link and provides a fallback message with a clickable link. The most important changes include importing necessary components and setting up the page structure with a redirect.

New `Apply` page setup:

* [`app/(application)/apply/page.tsx`](diffhunk://#diff-7dd8e905973a5902e9ebf1519bbb29807b5a5148b01aee4089bd59464eed0620R1-R33): Created a new `Apply` page that imports `Link` from `next/link`, `redirect` from `next/navigation`, `Loader2` from `lucide-react`, and custom components `Footer` and `Navbar`. The page redirects users to the application link and displays a message with a fallback clickable link and a loading spinner.

If the redirect doesn't work, it shows you this page:
![image](https://github.com/user-attachments/assets/6b8c3726-758a-4638-9342-835b8b4bac5e)