### PR TITLE
[fix] No more blur on team member and prize photos

### DIFF
--- a/app/(main)/_components/_prizes/prize.tsx
+++ b/app/(main)/_components/_prizes/prize.tsx
@@ -23,6 +23,7 @@ const Prize: FC<PrizeProps> = ({ title, description, imageSrc, imageSide = "left
         height={0}
         className={`w-28 sm:w-40 md:w-44 max-w-64 prize-image transform-gpu transition-transform duration-300 hover:scale-105 ${imageSide == "left" ? "hover:-rotate-6" : "hover:rotate-6"}`}
         draggable="false"
+        unoptimized
       />
       <div className="flex flex-col items-center justify-center text-center gap-y-2">
         <h2 className="text-2xl font-bold font-TangoSansBold text-primary">{title}</h2>

--- a/app/(main)/_components/_team/team-member.tsx
+++ b/app/(main)/_components/_team/team-member.tsx
@@ -20,6 +20,7 @@ const TeamMember: React.FC<ITeamMemberProps> = ({ name, teamRole, linkedinLink }
           alt={`${name}`}
           className="team-member w-24 h-24 sm:w-32 sm:h-32 select-none transform-gpu rounded-3xl"
           draggable={false}
+          unoptimized
         />
         <div>
           <p className="team-member-name md:pt-0 font-TangoSansBold text-primary text-base sm:text-xl text-center">


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have tested my changes locally and they work
- [x] My pull request targets the `main` branch of this repository.
- [x] I have organized any project files to the best of my ability

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
This pull request includes minor changes to optimize image loading by adding the `unoptimized` attribute to image components in two files.

Changes to image components:

* [`app/(main)/_components/_prizes/prize.tsx`](diffhunk://#diff-1bdb22ac723d0fe072262e591def418e0404c83277e2b50567385f5aa067b7e9R26): Added the `unoptimized` attribute to the image component to improve performance.
* [`app/(main)/_components/_team/team-member.tsx`](diffhunk://#diff-a5f82668380117c931d120b853e50e60712098c6f3718dc1c3ddc27603589248R23): Added the `unoptimized` attribute to the image component to improve performance.