### PR TITLE
[fix] Team member drop shadow dark instead of light

### DIFF
--- a/app/(main)/_components/_team/team-member.css
+++ b/app/(main)/_components/_team/team-member.css
@@ -1,11 +1,12 @@
 .team-member {
-  box-shadow: -4px 4px 15px 1px #fff;
+  box-shadow: -4px 4px 15px 1px rgba(0, 0, 0, 0.25);
 }
 
 .team-member-name {
-  text-shadow: 0px 4px 4px #fff;
+  text-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
 }
 
 .team-member-role {
-  text-shadow: 0px 4px 4px #fff;
+  text-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+
 }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have tested my changes locally and they work
- [x] My pull request targets the `main` branch of this repository.
- [x] I have organized any project files to the best of my ability

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
This change is due to the design changing from the gradient going up to the team section to now having it just below.

This pull request includes changes to the `app/(main)/_components/_team/team-member.css` file to improve the visual consistency of the team member component by updating the shadow styles.

Visual consistency improvements:

* [`app/(main)/_components/_team/team-member.css`](diffhunk://#diff-27748bd3d4a900871a6b04246c64a438154115b5fedd37e939c419a186d5e2f1L2-R11): Updated the `box-shadow` and `text-shadow` properties to use `rgba(0, 0, 0, 0.25)` instead of `#fff` for a more consistent and subtle shadow effect.

![image](https://github.com/user-attachments/assets/6927d0b1-065c-4781-9029-d41067edf6ff)
