### PR TITLE
[fix] Nav link + navbar size shifting

### DIFF
--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -37,7 +37,7 @@ const Navbar = () => {
       ref={navRef}
       className="m-[20px] w-[calc(100vw_-_40px)] rounded-[10px] fixed top-0 left-0 bg-primary z-[49] flex items-center box-border drop-shadow-lg"
     >
-      <div className="hidden lg:flex justify-between items-center w-full">
+      <div className="hidden [@media(min-width:805px)]:flex justify-between items-center w-full">
         <div className="flex flex-row items-center">
           <div className="flex items-center overflow-hidden">
             <NavLink

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -128,7 +128,7 @@ const Navbar = () => {
           </NavLink>
         </div>
       </div>
-      <div className="flex flex-col w-full lg:hidden">
+      <div className="flex flex-col w-full [@media(min-width:805px)]:hidden">
         <div className="flex items-center justify-between w-full overflow-hidden">
           <NavLink
             href="/"

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -40,7 +40,13 @@ const Navbar = () => {
       <div className="hidden md:flex justify-between items-center w-full">
         <div className="flex flex-row items-center">
           <div className="flex items-center overflow-hidden">
-            <NavLink href="/" variant={"logo"} className="h-[70px] rounded-l-[10px] group" aria-label="Home">
+            <NavLink
+              href="/"
+              variant={"logo"}
+              className="h-[70px] rounded-l-[10px] group"
+              aria-label="Home"
+              isExternalLink
+            >
               <Image
                 src="/logos/pantherhacks/pantherhacks_mascot_light.png"
                 alt="Panther Hacks Logo"
@@ -59,7 +65,7 @@ const Navbar = () => {
             <NavLink href="#prizes">Prizes</NavLink>
             <NavLink href="#faqs">FAQs</NavLink>
             <NavLink href="#team">Team</NavLink>
-            <NavLink href={applicationLink} variant="bold" className="bg-[rgb(75,0,0)]" target="_blank">
+            <NavLink isExternalLink href={applicationLink} variant="bold" className="bg-[rgb(75,0,0)]">
               APPLY
             </NavLink>
           </div>
@@ -71,6 +77,7 @@ const Navbar = () => {
             variant={"icon"}
             title={"PantherHacks GitHub Link"}
             aria-label={"PantherHacks GitHub Link"}
+            isExternalLink
           >
             <Image
               src="./icons/github.svg"
@@ -88,6 +95,7 @@ const Navbar = () => {
             variant={"icon"}
             title={"PantherHacks Discord Link"}
             aria-label={"PantherHacks Discord Link"}
+            isExternalLink
           >
             <Image
               src="./icons/discord.svg"
@@ -106,6 +114,7 @@ const Navbar = () => {
             className="rounded-r-[10px]"
             title={"PantherHacks Instagram Link"}
             aria-label={"PantherHacks Instagram Link"}
+            isExternalLink
           >
             <Image
               src="./icons/instagram.svg"
@@ -127,6 +136,7 @@ const Navbar = () => {
             className={cn("h-[70px]", isMobileOpen ? "rounded-tl-[10px]" : "rounded-l-[10px]")}
             aria-label="Home"
             onClick={handleMobileLinkClick}
+            isExternalLink
           >
             <Image
               src="/logos/pantherhacks/pantherhacks_mascot_light.png"
@@ -179,6 +189,7 @@ const Navbar = () => {
             className="bg-[rgb(75,0,0)]"
             onClick={handleMobileLinkClick}
             target="_blank"
+            isExternalLink
           >
             APPLY
           </NavLink>
@@ -190,6 +201,7 @@ const Navbar = () => {
               title={"PantherHacks GitHub Link"}
               aria-label={"PantherHacks GitHub Link"}
               onClick={handleMobileLinkClick}
+              isExternalLink
             >
               <Image
                 src="./icons/github.svg"
@@ -208,6 +220,7 @@ const Navbar = () => {
               title={"PantherHacks Discord Link"}
               aria-label={"PantherHacks Discord Link"}
               onClick={handleMobileLinkClick}
+              isExternalLink
             >
               <Image
                 src="./icons/discord.svg"
@@ -226,6 +239,7 @@ const Navbar = () => {
               target="_blank"
               variant={"mobile_icon"}
               onClick={handleMobileLinkClick}
+              isExternalLink
             >
               <Image
                 src="./icons/instagram.svg"

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -40,16 +40,10 @@ const Navbar = () => {
       <div className="hidden [@media(min-width:805px)]:flex justify-between items-center w-full">
         <div className="flex flex-row items-center">
           <div className="flex items-center overflow-hidden">
-            <NavLink
-              href="/"
-              variant={"logo"}
-              className="h-[70px] rounded-l-[10px] group"
-              aria-label="Home"
-              isExternalLink
-            >
+            <NavLink href="/" variant={"logo"} className="h-[70px] rounded-l-[10px] group" aria-label="Home">
               <Image
                 src="/logos/pantherhacks/pantherhacks_mascot_light.png"
-                alt="Panther Hacks Logo"
+                alt="PantherHacks Logo"
                 width={50}
                 height={50}
                 className="transition-transform duration-300 ease-in-out transform group-hover:scale-105 select-none"
@@ -59,13 +53,13 @@ const Navbar = () => {
             </NavLink>
           </div>
           <div className="flex items-center flex-grow font-TangoSans text-white text-lg">
-            <NavLink href="#home">Home</NavLink>
-            <NavLink href="#about">About</NavLink>
-            <NavLink href="#tracks">Tracks</NavLink>
-            <NavLink href="#prizes">Prizes</NavLink>
-            <NavLink href="#faqs">FAQs</NavLink>
-            <NavLink href="#team">Team</NavLink>
-            <NavLink isExternalLink href={applicationLink} variant="bold" className="bg-[rgb(75,0,0)]">
+            <NavLink href="/#home">Home</NavLink>
+            <NavLink href="/#about">About</NavLink>
+            <NavLink href="/#tracks">Tracks</NavLink>
+            <NavLink href="/#prizes">Prizes</NavLink>
+            <NavLink href="/#faqs">FAQs</NavLink>
+            <NavLink href="/#team">Team</NavLink>
+            <NavLink href={applicationLink} variant="bold" className="bg-[rgb(75,0,0)]">
               APPLY
             </NavLink>
           </div>
@@ -77,7 +71,6 @@ const Navbar = () => {
             variant={"icon"}
             title={"PantherHacks GitHub Link"}
             aria-label={"PantherHacks GitHub Link"}
-            isExternalLink
           >
             <Image
               src="./icons/github.svg"
@@ -95,7 +88,6 @@ const Navbar = () => {
             variant={"icon"}
             title={"PantherHacks Discord Link"}
             aria-label={"PantherHacks Discord Link"}
-            isExternalLink
           >
             <Image
               src="./icons/discord.svg"
@@ -114,7 +106,6 @@ const Navbar = () => {
             className="rounded-r-[10px]"
             title={"PantherHacks Instagram Link"}
             aria-label={"PantherHacks Instagram Link"}
-            isExternalLink
           >
             <Image
               src="./icons/instagram.svg"
@@ -136,7 +127,6 @@ const Navbar = () => {
             className={cn("h-[70px]", isMobileOpen ? "rounded-tl-[10px]" : "rounded-l-[10px]")}
             aria-label="Home"
             onClick={handleMobileLinkClick}
-            isExternalLink
           >
             <Image
               src="/logos/pantherhacks/pantherhacks_mascot_light.png"
@@ -165,22 +155,22 @@ const Navbar = () => {
             isMobileOpen ? "flex" : "hidden"
           )}
         >
-          <NavLink variant="mobile" href="#home" onClick={handleMobileLinkClick}>
+          <NavLink variant="mobile" href="/#home" onClick={handleMobileLinkClick}>
             Home
           </NavLink>
-          <NavLink variant="mobile" href="#about" onClick={handleMobileLinkClick}>
+          <NavLink variant="mobile" href="/#about" onClick={handleMobileLinkClick}>
             About
           </NavLink>
-          <NavLink variant="mobile" href="#tracks" onClick={handleMobileLinkClick}>
+          <NavLink variant="mobile" href="/#tracks" onClick={handleMobileLinkClick}>
             Tracks
           </NavLink>
-          <NavLink variant="mobile" href="#prizes" onClick={handleMobileLinkClick}>
+          <NavLink variant="mobile" href="/#prizes" onClick={handleMobileLinkClick}>
             Prizes
           </NavLink>
-          <NavLink variant="mobile" href="#faqs" onClick={handleMobileLinkClick}>
+          <NavLink variant="mobile" href="/#faqs" onClick={handleMobileLinkClick}>
             FAQs
           </NavLink>
-          <NavLink variant="mobile" href="#team" onClick={handleMobileLinkClick}>
+          <NavLink variant="mobile" href="/#team" onClick={handleMobileLinkClick}>
             Team
           </NavLink>
           <NavLink
@@ -189,7 +179,6 @@ const Navbar = () => {
             className="bg-[rgb(75,0,0)]"
             onClick={handleMobileLinkClick}
             target="_blank"
-            isExternalLink
           >
             APPLY
           </NavLink>
@@ -201,7 +190,6 @@ const Navbar = () => {
               title={"PantherHacks GitHub Link"}
               aria-label={"PantherHacks GitHub Link"}
               onClick={handleMobileLinkClick}
-              isExternalLink
             >
               <Image
                 src="./icons/github.svg"
@@ -220,7 +208,6 @@ const Navbar = () => {
               title={"PantherHacks Discord Link"}
               aria-label={"PantherHacks Discord Link"}
               onClick={handleMobileLinkClick}
-              isExternalLink
             >
               <Image
                 src="./icons/discord.svg"
@@ -239,7 +226,6 @@ const Navbar = () => {
               target="_blank"
               variant={"mobile_icon"}
               onClick={handleMobileLinkClick}
-              isExternalLink
             >
               <Image
                 src="./icons/instagram.svg"

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -37,7 +37,7 @@ const Navbar = () => {
       ref={navRef}
       className="m-[20px] w-[calc(100vw_-_40px)] rounded-[10px] fixed top-0 left-0 bg-primary z-[49] flex items-center box-border drop-shadow-lg"
     >
-      <div className="hidden md:flex justify-between items-center w-full">
+      <div className="hidden lg:flex justify-between items-center w-full">
         <div className="flex flex-row items-center">
           <div className="flex items-center overflow-hidden">
             <NavLink
@@ -128,7 +128,7 @@ const Navbar = () => {
           </NavLink>
         </div>
       </div>
-      <div className="flex flex-col w-full md:hidden">
+      <div className="flex flex-col w-full lg:hidden">
         <div className="flex items-center justify-between w-full overflow-hidden">
           <NavLink
             href="/"

--- a/components/ui/NavLink.tsx
+++ b/components/ui/NavLink.tsx
@@ -29,11 +29,17 @@ export interface NavLinkProps
     VariantProps<typeof navLinkVariants> {
   children?: React.ReactNode;
   className?: string;
+  isExternalLink?: boolean;
 }
 
-export function NavLink({ href, children, variant, className, ...props }: NavLinkProps) {
+export function NavLink({ href, children, variant, className, isExternalLink = false, ...props }: NavLinkProps) {
   return (
-    <Link href={`/${href}`} className={cn("select-none", navLinkVariants({ variant }), className)} {...props}>
+    <Link
+      href={`${isExternalLink ? "" : "/"}${href}`}
+      className={cn("select-none", navLinkVariants({ variant }), className)}
+      target={isExternalLink ? "_blank" : ""}
+      {...props}
+    >
       {children}
     </Link>
   );

--- a/components/ui/NavLink.tsx
+++ b/components/ui/NavLink.tsx
@@ -29,17 +29,11 @@ export interface NavLinkProps
     VariantProps<typeof navLinkVariants> {
   children?: React.ReactNode;
   className?: string;
-  isExternalLink?: boolean;
 }
 
-export function NavLink({ href, children, variant, className, isExternalLink = false, ...props }: NavLinkProps) {
+export function NavLink({ href, children, variant, className, ...props }: NavLinkProps) {
   return (
-    <Link
-      href={`${isExternalLink ? "" : "/"}${href}`}
-      className={cn("select-none", navLinkVariants({ variant }), className)}
-      target={isExternalLink ? "_blank" : ""}
-      {...props}
-    >
+    <Link href={href} className={cn("select-none", navLinkVariants({ variant }), className)} {...props}>
       {children}
     </Link>
   );


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have tested my changes locally and they work
- [x] My pull request targets the `main` branch of this repository.
- [x] I have organized any project files to the best of my ability

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
This pull request includes several changes to the `Navbar` component and the `NavLink` component to improve the handling of external links and adjust responsive design breakpoints. The most important changes are listed below:

Enhancements to `NavLink` component:

* [`components/ui/NavLink.tsx`](diffhunk://#diff-ffd44e8bfae1ec2aabf11baf4c94990286c259111781e2ecf559b839256f495bR32-R42): Added a new `isExternalLink` prop to the `NavLink` component to handle external links, setting the `target` attribute to `_blank` when `isExternalLink` is true.

Updates to `Navbar` component:

* [`components/navbar.tsx`](diffhunk://#diff-697415f51799297bd64388e550f60789de985cb60aca6be2175bc512c9243626L40-R49): Changed the responsive design breakpoint from `md` to `lg` for displaying the full navbar. [[1]](diffhunk://#diff-697415f51799297bd64388e550f60789de985cb60aca6be2175bc512c9243626L40-R49) [[2]](diffhunk://#diff-697415f51799297bd64388e550f60789de985cb60aca6be2175bc512c9243626L122-R139)
* [`components/navbar.tsx`](diffhunk://#diff-697415f51799297bd64388e550f60789de985cb60aca6be2175bc512c9243626L40-R49): Added the `isExternalLink` prop to various `NavLink` instances to properly handle external links. [[1]](diffhunk://#diff-697415f51799297bd64388e550f60789de985cb60aca6be2175bc512c9243626L40-R49) [[2]](diffhunk://#diff-697415f51799297bd64388e550f60789de985cb60aca6be2175bc512c9243626L62-R68) [[3]](diffhunk://#diff-697415f51799297bd64388e550f60789de985cb60aca6be2175bc512c9243626R80) [[4]](diffhunk://#diff-697415f51799297bd64388e550f60789de985cb60aca6be2175bc512c9243626R98) [[5]](diffhunk://#diff-697415f51799297bd64388e550f60789de985cb60aca6be2175bc512c9243626R117) [[6]](diffhunk://#diff-697415f51799297bd64388e550f60789de985cb60aca6be2175bc512c9243626R192) [[7]](diffhunk://#diff-697415f51799297bd64388e550f60789de985cb60aca6be2175bc512c9243626R204) [[8]](diffhunk://#diff-697415f51799297bd64388e550f60789de985cb60aca6be2175bc512c9243626R223) [[9]](diffhunk://#diff-697415f51799297bd64388e550f60789de985cb60aca6be2175bc512c9243626R242)