### PR TITLE
[fix] Asymmetrical padding after countdown

### DIFF
--- a/app/(main)/_components/countdown.tsx
+++ b/app/(main)/_components/countdown.tsx
@@ -73,7 +73,7 @@ const Countdown = () => {
   }, [hackathonStartDate, hackathonEndDate, applicationSubmissionDate]); // Add dependencies to re-run effect if dates change
 
   return (
-    <div className="flex flex-col gap-y-2 justify-center items-center pb-16 md:pb-32 lg:pb-20">
+    <div className="flex flex-col gap-y-2 justify-center items-center">
       <h2
         className={`text-3xl sm:text-5xl md:text-5xl font-TangoSansBold text-primary${hackathonConcluded ? " hidden" : ""}`}
       >


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have tested my changes locally and they work
- [x] My pull request targets the `main` branch of this repository.
- [x] I have organized any project files to the best of my ability

<!-- Feel free to add any additional description of changes below this line -->
This pull request includes a small change to the `Countdown` component in the `app/(main)/_components/countdown.tsx` file. The change removes unnecessary padding from the div element.

* [`app/(main)/_components/countdown.tsx`](diffhunk://#diff-ea1f44d41914038168b252e1805c51f086fc71f8c556e3ebb2f964cbcdc28579L76-R76): Removed `pb-16 md:pb-32 lg:pb-20` padding classes from the div element to simplify the component's styling.

Before:
![image](https://github.com/user-attachments/assets/113f2282-59cb-43b1-ab6d-92a9a310f217)

After:
![image](https://github.com/user-attachments/assets/25cba8f7-b2cf-4881-9261-72982f5f7dba)
