### PR TITLE
[added] Fullscreen button for countdown page

### DIFF
--- a/app/(event)/countdown/page.tsx
+++ b/app/(event)/countdown/page.tsx
@@ -3,13 +3,14 @@
 import { useCallback, useEffect, useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
-import { Home, Radio } from "lucide-react";
+import { Home, Maximize, Minimize, Radio } from "lucide-react";
 
 import Countdown from "@/components/countdown";
 import { Button } from "@/components/ui/button";
 
 const CountdownPage = () => {
   const [showButton, setShowButton] = useState<boolean>(true);
+  const [isFullscreen, setIsFullscreen] = useState(false);
   const [position, setPosition] = useState<number>(-200);
   const [rotation, setRotation] = useState<number>(0);
 
@@ -34,6 +35,26 @@ const CountdownPage = () => {
       document.body.style.cursor = "default";
     };
   }, []);
+
+  useEffect(() => {
+    const handleFullscreenChange = () => {
+      setIsFullscreen(!!document.fullscreenElement);
+    };
+
+    document.addEventListener("fullscreenchange", handleFullscreenChange);
+
+    return () => {
+      document.removeEventListener("fullscreenchange", handleFullscreenChange);
+    };
+  }, []);
+
+  const toggleFullscreen = () => {
+    if (!document.fullscreenElement) {
+      document.documentElement.requestFullscreen();
+    } else {
+      document.exitFullscreen();
+    }
+  };
 
   const animate = useCallback(() => {
     const speed = 1;
@@ -102,6 +123,14 @@ const CountdownPage = () => {
           <Radio />
         </Button>
       </Link>
+      <Button
+        className={`absolute top-4 right-4 px-3 py-2 bg-transparent hover:bg-[#83022b] transition-opacity duration-300 ${
+          showButton ? "opacity-100" : "opacity-0"
+        }`}
+        onClick={toggleFullscreen}
+      >
+        {isFullscreen ? <Minimize /> : <Maximize />}
+      </Button>
       <div className="z-50">
         <Countdown dark size="large" />
       </div>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have tested my changes locally and they work
- [x] My pull request targets the `main` branch of this repository.
- [x] I have organized any project files to the best of my ability

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
This pull request enhances the `CountdownPage` component by introducing fullscreen functionality and improving user interaction. The most important changes include adding a new state to track fullscreen mode, implementing a toggle function for fullscreen, and updating the UI with a button to control this feature.

### Fullscreen functionality:

* Added a new `isFullscreen` state to track whether the document is in fullscreen mode (`app/(event)/countdown/page.tsx`, [app/(event)/countdown/page.tsxL6-R13](diffhunk://#diff-de113fe06ab5716fb5c07a7196d924d08d6f8d792cd292339f98a052b8cddbb3L6-R13)).
* Implemented a `toggleFullscreen` function to enter or exit fullscreen mode using the `requestFullscreen` and `exitFullscreen` APIs (`app/(event)/countdown/page.tsx`, [app/(event)/countdown/page.tsxR39-R58](diffhunk://#diff-de113fe06ab5716fb5c07a7196d924d08d6f8d792cd292339f98a052b8cddbb3R39-R58)).
* Added an event listener for `fullscreenchange` to keep the `isFullscreen` state in sync with the document's fullscreen status (`app/(event)/countdown/page.tsx`, [app/(event)/countdown/page.tsxR39-R58](diffhunk://#diff-de113fe06ab5716fb5c07a7196d924d08d6f8d792cd292339f98a052b8cddbb3R39-R58)).

### UI updates:

* Added a new button to the UI, allowing users to toggle fullscreen mode. The button dynamically displays either a `Maximize` or `Minimize` icon based on the `isFullscreen` state (`app/(event)/countdown/page.tsx`, [app/(event)/countdown/page.tsxR126-R133](diffhunk://#diff-de113fe06ab5716fb5c07a7196d924d08d6f8d792cd292339f98a052b8cddbb3R126-R133)).

![image](https://github.com/user-attachments/assets/f74d2cb4-c851-40ef-96e1-ae0cf7e16124)
